### PR TITLE
dplyr 1.0.8, problem with use `slice()` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     plyr,
     dplyr (>= 0.7.5),
     tidyr,
-     doParallel
+    doParallel, 
+    tibble
 Suggests:
     knitr,
     gridExtra,

--- a/R/PPforest.R
+++ b/R/PPforest.R
@@ -62,6 +62,7 @@ PPforest <- function(data, class, std = TRUE, size.tr = 2/3, m = 500, PPmethod, 
     clnum <- as.numeric(as.factor(data[, class]))
     tr.index <- trainfn(as.matrix(clnum), as.matrix(data[, setdiff(colnames(data), class)]), 
         sizetr = size.tr) + 1
+    tr.index <- as.vector(tr.index)
     train <- data %>% dplyr::slice(tr.index)
     
     type = "Classification"

--- a/R/PPforest.R
+++ b/R/PPforest.R
@@ -54,7 +54,7 @@ PPforest <- function(data, class, std = TRUE, size.tr = 2/3, m = 500, PPmethod, 
     id <- NULL
 
     if (std) {
-        dataux <- data %>% dplyr::select(-(!!class)) %>% apply(2, FUN = scale) %>% dplyr::as_data_frame()
+        dataux <- data %>% dplyr::select(-(!!class)) %>% apply(2, FUN = scale) %>% tibble::as_tibble()
         data <- data.frame(data[, class], dataux)
         colnames(data)[1] <- class
     }
@@ -104,7 +104,7 @@ PPforest <- function(data, class, std = TRUE, size.tr = 2/3, m = 500, PPmethod, 
     
   
     error.tr <- 1 - sum(as.numeric(as.factor(unlist(train[, class]))) == pred.tr$predforest)/length(pred.tr$predforest)
-    test <- data[-tr.index, ] %>% dplyr::select(-(!!class)) %>% dplyr::filter_()
+    test <- data[-tr.index, ] %>% dplyr::select(-(!!class))
     
     if (dim(test)[1] != 0) {
         pred.test <- trees_pred(outputaux, xnew = test, parallel, cores = cores, rule = rule)

--- a/R/baggtree.R
+++ b/R/baggtree.R
@@ -46,12 +46,12 @@ baggtree <- function(data, class, m = 500, PPmethod = "LDA", lambda = 0.1, size.
     
     doParallel::registerDoParallel(cores)
             
-           pp <- plyr::dlply(dplyr::data_frame(bootsam = 1:m), plyr::.(bootsam), function(x) boottree(data, 
+           pp <- plyr::dlply(tibble::tibble(bootsam = 1:m), plyr::.(bootsam), function(x) boottree(data, 
                 class, PPmethod, lambda, size.p), .parallel = parallel)
           
            doParallel::stopImplicitCluster()
         }else{
-            pp <- plyr::dlply(dplyr::data_frame(bootsam = 1:m), plyr::.(bootsam), function(x) boottree(data, 
+            pp <- plyr::dlply(tibble::tibble(bootsam = 1:m), plyr::.(bootsam), function(x) boottree(data, 
                 class, PPmethod, lambda, size.p), .parallel = parallel)
             
         }


### PR DESCRIPTION
We're about to release dplyr 1.0.8, and as part of our rev dep checks, we've identified that this package fails with: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘PPforest-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: PPforest
  > ### Title: Projection Pursuit Random Forest
  > ### Aliases: PPforest
  > 
  > ### ** Examples
  > 
  > #crab example with all the observations used as training
  > 
  > pprf.crab <- PPforest(data = crab, class = 'Type',
  +  std = FALSE, size.tr = 1, m = 100, size.p = .5, 
  +  PPmethod = 'LDA' , parallel = TRUE, cores = 2, rule=1)
  Error in `stop_vctrs()`: Can't convert <integer[,1]> to <integer>.
  Cannot decrease dimensions.
  Backtrace:
       ▆
    1. ├─PPforest::PPforest(...)
    2. │ └─data %>% dplyr::slice(tr.index)
    3. ├─dplyr::slice(., tr.index)
    4. └─dplyr:::slice.data.frame(., tr.index)
    5.   └─dplyr:::slice_impl(.data, ..., .preserve = .preserve)
    6.     └─dplyr:::slice_rows(.data, ..., caller_env = caller_env(2), error_call = error_call)
    7.       └─dplyr:::slice_combine(chunks, mask = mask, error_call = error_call)
    8.         └─vctrs::vec_cast(res, integer())
    9.           └─vctrs `<fn>`()
   10.             └─vctrs:::vec_cast.integer.double(...)
   11.               └─vctrs:::shape_broadcast(out, to, x_arg = x_arg, to_arg = to_arg)
   12.                 └─vctrs::stop_incompatible_cast(...)
   13.                   └─vctrs::stop_incompatible_type(...)
   14.                     └─vctrs:::stop_incompatible(...)
   15.                       └─vctrs:::stop_vctrs(...)
  Execution halted

> checking installed package size ... NOTE
    installed size is  8.3Mb
    sub-directories of 1Mb or more:
      libs   7.2Mb

1 error x | 0 warnings ✓ | 1 note x
````

I believe this is because `slice()` is stricter now, and does not allow matrices anymore. Please consider this pull request or let us know if we missed something. 